### PR TITLE
Fix tag mismatch warning

### DIFF
--- a/sourcemod/addons/sourcemod/scripting/hawthorne/humanize.sp
+++ b/sourcemod/addons/sourcemod/scripting/hawthorne/humanize.sp
@@ -78,5 +78,5 @@ stock int DehumanizeTime(char[] time, int size) {
     SplitString(time, "m", minutes, sizeof(minutes));
     iminutes = (StringToInt(minutes)) * 60;
   }
-  return RoundToFloor(idays + ihours + iminutes);
+  return idays + ihours + iminutes;
 }


### PR DESCRIPTION
hawthorne/humanize.sp(81) : warning 213: tag mismatch

Why "RoundToFloor" if  we are summing only ints?