### PR TITLE
Install the latest git on CentOS

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -221,6 +221,7 @@ install() {
 
     hash git >/dev/null 2>&1 || {
       printf "${YELLOW}Git not preinstalled. Reinstalling...${NORMAL}\n"
+      yum install http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-2.noarch.rpm
       yum -y install git
     }
 


### PR DESCRIPTION
Install latest git version (2.x) to handle the ```hawthorne update``` on CentOS(7.x I suppose) command, since at the moment I had to update it(git) by myself.
Source: https://stackoverflow.com/a/27674776/8745788